### PR TITLE
Enable chat button for non-SSO Slack/chat

### DIFF
--- a/html-templates/projects/project.tpl
+++ b/html-templates/projects/project.tpl
@@ -85,24 +85,27 @@
             <div role="group" aria-label="...">
                 {if $Project->UsersUrl}
                     <a class="btn btn-primary btn-block" role="button" href="{$Project->UsersUrl|escape}">
-                        {glyph "user"}&nbsp;Users' Site
+                        {glyph "user"}&nbsp;{_ "Users' Site"}
                         <div class="small">{$Project->UsersUrl|escape}</div>
                     </a>
                 {/if}
                 {if $Project->DevelopersUrl}
                     <a class="btn btn-success btn-block" role="button" href="{$Project->DevelopersUrl|escape}">
-                        {glyph "cog"}&nbsp;Developers' Site
+                        {glyph "cog"}&nbsp;{_ "Developers' Site"}
                         <div class="small">{$Project->DevelopersUrl|escape}</div>
                     </a>
                 {/if}
                 {if $Project->ChatChannel}
                     {if Laddr::$chatLinker}
                         <a class="btn btn-success btn-block" role="button" href="{call_user_func(Laddr::$chatLinker, $Project->ChatChannel)|escape}" target="_blank">
-                            {glyph "comment"}&nbsp;Chat Channel
+                            {glyph "comment"}&nbsp;{_ "Chat Channel"}
                             <div class="small">#{$Project->ChatChannel|escape}</div>
                         </a>
                     {else}
-                        <p class="text-center">Chat Channel: <strong>#{$Project->ChatChannel|escape}</strong></p>
+                        <a class="btn btn-success btn-block" role="button" href="/chat?channel={$Project->ChatChannel|escape}" target="_blank">
+                            {glyph "comment"}&nbsp;{_ "Chat Channel"}
+                            <div class="small">#{$Project->ChatChannel|escape}</div>
+                        </a>
                     {/if}
                 {/if}
             </div>


### PR DESCRIPTION
enabling button strings for translations
adding button for non-SSO Slack chat (pointing to /chat?channel=XXX, a chat defined in chat.php)