### PR TITLE
Release: laddr v2.3.5

### DIFF
--- a/html-templates/projects/projectEdit.tpl
+++ b/html-templates/projects/projectEdit.tpl
@@ -51,7 +51,7 @@
                     </div>
                     <div class="form-group">
                         <label for="field-chat-channel">{_ "Chat Channel/Hashtag"}:</label>
-                        <input name="ChatChannel" id="field-chat-channel" class="form-control" placeholder="train_schedule_analyzer" value="{refill field=ChatChannel default=$Project->ChatChannel}" pattern="[A-Za-z0-9_]+" title="Hash tag containing only letters, numbers, or underscores without leading #"/>
+                        <input name="ChatChannel" id="field-chat-channel" class="form-control" placeholder="train_schedule_analyzer" value="{refill field=ChatChannel default=$Project->ChatChannel}" pattern="[A-Za-z0-9_-]+" title="Hash tag containing only letters, numbers, dashes or underscores without leading #"/>
                     </div>
                     <div class="form-group">
                         <label for="topicTagsInput">{_ 'Topic Tags'}:</label>

--- a/html-templates/projects/projectSaved.tpl
+++ b/html-templates/projects/projectSaved.tpl
@@ -1,6 +1,6 @@
 {extends designs/site.tpl}
 
-{block title}Saved {$data->Title|escape} &mdash; Projects &mdash; {$dwoo.parent}{/block}
+{block title}{_ 'Saved'} {$data->Title|escape} &mdash; {_ 'Projects'} &mdash; {$dwoo.parent}{/block}
 
 {block content}
     {$Project = $data}

--- a/php-config/Laddr.config.d/chat.php
+++ b/php-config/Laddr.config.d/chat.php
@@ -2,12 +2,6 @@
 
 /*
 Laddr::$chatLinker = function($channel = null) {
-    $url = '/chat';
-
-    if ($channel) {
-        $url .= '?channel=' . urlencode($channel);
-    }
-
-    return $url;
+    return 'https://mySlackOrg.slack.com/messages/'.urlencode($channel ?: 'general').'/';
 };
 */

--- a/site-root/chat.php
+++ b/site-root/chat.php
@@ -1,13 +1,8 @@
 <?php
 
-// TODO: delete/comment this line and use this file to implement a gateway to your group's chat system
-return RequestHandler::throwError('The administrator of this site has not yet implemented a redirect to your chat provider');
+if (Laddr::$chatLinker) {
+    $url = call_user_func(Laddr::$chatLinker, !empty($_GET['channel']) ? $_GET['channel'] : null);
+    Site::redirect($url);
+}
 
-// $_GET['channel'] may be provided to indicate a specific channel to redirect to
-
-// EXAMPLE 1: Redirect to Slack with authentication provided via SAML Single Sign On
-//$GLOBALS['Session']->requireAuthentication();
-//Site::redirect('https://codeforphilly.slack.com/sso/saml/start?redir=%2Fmessages%2F'.urlencode(!empty($_GET['channel']) ? $_GET['channel'] : 'general').'%2F');
-
-// EXAMPLE 2: Redirect to Slack without SSO
-//Site::redirect('https://codeforphilly.slack.com/messages/'.urlencode(!empty($_GET['channel']) ? $_GET['channel'] : 'general').'/');
+RequestHandler::throwError('The administrator of this site has not yet configured Laddr:$chatLinker');

--- a/site-root/chat.php
+++ b/site-root/chat.php
@@ -1,0 +1,13 @@
+<?php
+
+// TODO: delete/comment this line and use this file to implement a gateway to your group's chat system
+return RequestHandler::throwError('The administrator of this site has not yet implemented a redirect to your chat provider');
+
+// $_GET['channel'] may be provided to indicate a specific channel to redirect to
+
+// EXAMPLE 1: Redirect to Slack with authentication provided via SAML Single Sign On
+//$GLOBALS['Session']->requireAuthentication();
+//Site::redirect('https://codeforphilly.slack.com/sso/saml/start?redir=%2Fmessages%2F'.urlencode(!empty($_GET['channel']) ? $_GET['channel'] : 'general').'%2F');
+
+// EXAMPLE 2: Redirect to Slack without SSO
+//Site::redirect('https://codeforphilly.slack.com/messages/'.urlencode(!empty($_GET['channel']) ? $_GET['channel'] : 'general').'/');


### PR DESCRIPTION
- Provide example for linking directly to Slack for chat
- Add a default `/chat` route for redirecting users to configured chat medium with optional `?chanel=XXX` parameter
- Allow hyphen in project chat channel setting
- Add missing `gettext` wrappers for translation on project saved confirmation page